### PR TITLE
Readme: Installation step fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ With Bundler
 ```ruby
 group :development do
   # Github
-  gem 'slimkeyfy', github: 'https://github.com/phrase/slimkeyfy.git'
+  gem 'slimkeyfy', github: 'phrase/slimkeyfy'
   # or with concrete version
-  gem 'slimkeyfy', '~> 0.X'
+  # gem 'slimkeyfy', '~> 0.X'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ With Bundler
 ```ruby
 group :development do
   # Github
-  gem 'slimkeyfy', github: 'phrase/slimkeyfy'
+  # gem 'slimkeyfy', github: 'phrase/slimkeyfy'
   # or with concrete version
-  # gem 'slimkeyfy', '~> 0.X'
+  gem 'slimkeyfy', '~> 0.1'
 end
 ```
 


### PR DESCRIPTION
- fixes github repository name to avoid the error during the bundle install
```
fatal: remote error:
  https://github.com/phrase/slimkeyfy.git is not a valid repository name
  Visit https://support.github.com/ for help

Git error: command `git clone 'git://github.com/https://github.com/phrase/slimkeyfy.git.git' [....] failed.
```
- allowing copy-paste installation